### PR TITLE
Migration file creates network settings for build artifacts

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -3,61 +3,71 @@ var RequestEthereum = artifacts.require("./RequestEthereum.sol");
 var RequestSynchroneExtensionEscrow = artifacts.require("./RequestSynchroneExtensionEscrow.sol");
 var RequestBurnManagerSimple = artifacts.require("./RequestBurnManagerSimple.sol");
 
-// Copy & Paste this
-Date.prototype.getUnixTime = function() { return this.getTime()/1000|0 };
-if(!Date.now) Date.now = function() { return new Date(); }
-Date.time = function() { return Date.now().getUnixTime(); }
-
-
 var addressContractBurner = 0;
 var feesPerTenThousand = 10; // 0.1 %
 
 
-var requestCoreContract;
+var requestCore;
 var requestEthereum;
 var requestEscrow;
 var requestBurnManagerSimple;
 
 module.exports = function(deployer) {
-		return RequestCore.new().then(function(result){
-			requestCoreContract = result;
-				console.log("requestCore: "+requestCoreContract.address);
-				RequestEthereum.new(requestCoreContract.address).then(function(result){
-					requestEthereum=result;
-					console.log("requestEthereum: "+result.address);
-
-						RequestBurnManagerSimple.new(addressContractBurner).then(function(result){
-							requestBurnManagerSimple=result;
-							console.log("requestBurnManagerSimple: "+result.address);
-
-							requestBurnManagerSimple.setFeesPerTenThousand(feesPerTenThousand).then(function(result){
-								requestCoreContract.setBurnManager(requestBurnManagerSimple.address).then(function(result){
-										requestCoreContract.adminAddTrustedCurrencyContract(requestEthereum.address).then(function(r) {
-											RequestSynchroneExtensionEscrow.new(requestCoreContract.address).then(function(result){
-												requestEscrow=result;
-
-												console.log("RequestSynchroneExtensionEscrow: "+result.address);
-												requestCoreContract.adminAddTrustedExtension(result.address).then(function(r) {
-													requestCoreContract.getStatusContract(requestEthereum.address).then(function(d) {
-												    console.log("getStatusContract: " + requestEthereum.address + " => " + d)
-													})
-													requestCoreContract.getStatusExtension(requestEscrow.address).then(function(d) {
-												    console.log("getStatusExtension: " + requestEscrow.address + " => " + d)
-													})	
-
-													requestBurnManagerSimple.feesPer10000().then(function(d) {
-												    console.log("trustedNewBurnManager %% => " + d);
-													})	
-													requestCoreContract.trustedNewBurnManager().then(function(d) {
-												    console.log("trustedNewBurnManager manager => " + d);
-													})											
-												});
-											});
-										});
-								});
-							});
-					});
-			});
-		});
+    deployer.deploy(RequestCore).then(function() {
+        return deployer.deploy(RequestEthereum, RequestCore.address).then(function() {
+            return deployer.deploy(RequestBurnManagerSimple, addressContractBurner).then(function() {
+                return deployer.deploy(RequestSynchroneExtensionEscrow, RequestCore.address).then(function() {
+                    createInstances().then(function() {
+                        setupContracts().then(function() {
+                            checks()
+                        });
+                    });
+                });
+            });
+        });
+    });
 };
 
+var createInstances = function() {
+    return RequestCore.deployed().then(function(instance) {
+        requestCore = instance;
+        return RequestEthereum.deployed().then(function(instance) {
+            requestEthereum = instance;
+            return RequestBurnManagerSimple.deployed().then(function(instance) {
+                requestBurnManagerSimple = instance;
+                return RequestSynchroneExtensionEscrow.deployed().then(function(instance) {
+                    requestEscrow = instance;
+                    console.log("Instances set.")
+                });
+            });
+        });
+    });
+}
+
+var setupContracts = function() {
+    return requestBurnManagerSimple.setFeesPerTenThousand(feesPerTenThousand).then(function() {
+        return requestCore.setBurnManager(requestBurnManagerSimple.address).then(function() {
+            return requestCore.adminAddTrustedCurrencyContract(requestEthereum.address).then(function() {
+                return requestCore.adminAddTrustedExtension(requestEscrow.address).then(function() {
+                    console.log("Contracts set up.")
+                });
+            });
+        });
+    });
+}
+
+var checks = function() {
+  requestCore.getStatusContract(requestEthereum.address).then(function(d) {
+    console.log("getStatusContract: " + requestEthereum.address + " => " + d)
+  });
+  requestCore.getStatusExtension(requestEscrow.address).then(function(d) {
+    console.log("getStatusExtension: " + requestEscrow.address + " => " + d)
+  });
+  requestBurnManagerSimple.feesPer10000().then(function(d) {
+    console.log("trustedNewBurnManager %% => " + d);
+  });
+  requestCore.trustedNewBurnManager().then(function(d) {
+    console.log("trustedNewBurnManager manager => " + d);
+    console.log("Checks complete")
+  });
+}


### PR DESCRIPTION
## What was wrong?

When running the migration files, the build artifacts for `RequestEthereum`, `RequestSynchroneExtensionEscrow`, and `RequestBurnManagerSimple` are not created with network settings thus making it hard to develop efficiently in the truffle environment (for example: `contractName.deployed()` can't be called on the above contracts).

##How was it fixed?

`Deployer.deploy()` logic was used in a promise chain that then returned the deployed objects. Additionally, for clarity much of the set up process was modularized into creating instances, calling necessary contract set up functions, and running checks to make sure the deployed contracts' settings are correct. 